### PR TITLE
fix(sts): increase retry attempts for AssumeRoot throttling

### DIFF
--- a/internal/aws/config.go
+++ b/internal/aws/config.go
@@ -2,8 +2,10 @@ package aws
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 )
@@ -26,6 +28,18 @@ func WithCredentials(creds *aws.Credentials) configOption {
 func WithDefaultRegion(region string) configOption {
 	return func(o *config.LoadOptions) error {
 		o.DefaultRegion = region
+		return nil
+	}
+}
+
+func WithRetry(maxAttempts int, maxBackoff time.Duration) configOption {
+	return func(o *config.LoadOptions) error {
+		o.Retryer = func() aws.Retryer {
+			return retry.NewStandard(func(s *retry.StandardOptions) {
+				s.MaxAttempts = maxAttempts
+				s.MaxBackoff = maxBackoff
+			})
+		}
 		return nil
 	}
 }

--- a/rootmanager/manager.go
+++ b/rootmanager/manager.go
@@ -3,6 +3,7 @@ package rootmanager
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/unicrons/aws-root-manager/internal/aws"
 )
@@ -28,9 +29,15 @@ func NewRootManager(ctx context.Context) (RootManager, error) {
 	if err != nil {
 		return nil, err
 	}
+	// AssumeRoot is subject to strict AWS rate limits, so the STS client uses
+	// a more aggressive retry policy than the default.
+	stsCfg, err := aws.LoadAWSConfig(ctx, aws.WithRetry(10, 30*time.Second))
+	if err != nil {
+		return nil, err
+	}
 	return newManager(
 		aws.NewIamClient(cfg),
-		aws.NewStsClient(cfg),
+		aws.NewStsClient(stsCfg),
 		aws.NewOrganizationsClient(cfg),
 		&aws.DefaultIamClientFactory{},
 	), nil


### PR DESCRIPTION
Add WithRetry configOption to LoadAWSConfig and apply it exclusively to the STS client to handle AWS rate limits on AssumeRoot without affecting IAM or Organizations clients.