### PR TITLE
feat(confirm): require explicit --yes in non-interactive environments

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -28,7 +28,7 @@ func Delete(newRM func(context.Context) (rootmanager.RootManager, error)) *cobra
 	cmd.AddCommand(deleteSubcommand(newRM, "certificates", "Delete root user Signin Certificates", "Delete existing root user Signing Certificates for specific AWS Organization member accounts."))
 	cmd.AddCommand(DeleteS3BucketPolicy(newRM))
 	cmd.AddCommand(DeleteSQSQueuePolicy(newRM))
-	cmd.PersistentFlags().BoolVar(&skipFlag, "skip", false, "Skip the confirmation prompt")
+	cmd.PersistentFlags().BoolVar(&skipFlag, "yes", false, "Skip the confirmation prompt")
 	return cmd
 }
 
@@ -72,7 +72,7 @@ func runDelete(newRM func(context.Context) (rootmanager.RootManager, error), w i
 	}
 	slog.Debug("selected accounts", "accounts", strings.Join(auditAccounts, ", "))
 
-	if outputFlag == "table" && !skipFlag {
+	if !skipFlag {
 		confirmed, err := ui.Confirm(fmt.Sprintf("Delete %s root credentials for %d account(s)?", credentialType, len(auditAccounts)))
 		if err != nil {
 			return err

--- a/cmd/delete_s3_bucket_policy.go
+++ b/cmd/delete_s3_bucket_policy.go
@@ -71,16 +71,16 @@ func runDeleteS3BucketPolicy(newRM func(context.Context) (rootmanager.RootManage
 	if outputFlag == "table" {
 		fmt.Fprintf(w, "Current bucket policy for %s:\n\n", bucketName)
 		output.RenderPolicy(w, policy)
+	}
 
-		if !skipFlag {
-			confirmed, err := ui.Confirm("Delete this policy?")
-			if err != nil {
-				return err
-			}
-			if !confirmed {
-				fmt.Fprintln(w, "Aborted.")
-				return nil
-			}
+	if !skipFlag {
+		confirmed, err := ui.Confirm("Delete this policy?")
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(w, "Aborted.")
+			return nil
 		}
 	}
 

--- a/cmd/delete_s3_bucket_policy_test.go
+++ b/cmd/delete_s3_bucket_policy_test.go
@@ -10,9 +10,6 @@ import (
 	"github.com/unicrons/aws-root-manager/rootmanager"
 )
 
-// When getBucketPolicyResult is empty, the command prints "No bucket policy found." and exits
-// without invoking the TUI confirmation — safe to use in tests.
-
 func TestDeleteS3BucketPolicyCommand_NoPolicyFound(t *testing.T) {
 	mock := &mockRootManager{
 		getBucketPolicyResult: "",
@@ -53,9 +50,6 @@ func TestDeleteS3BucketPolicyCommand_FactoryError(t *testing.T) {
 
 func TestDeleteS3BucketPolicyCommand_DeletionFailure(t *testing.T) {
 	mock := &mockRootManager{
-		// Return non-empty policy so get succeeds, but deletion fails.
-		// Confirmation TUI is skipped because tests aren't interactive —
-		// PromptSingle returns -1 (no selection), which maps to "No".
 		getBucketPolicyResult: `{"Version":"2012-10-17"}`,
 		deleteBucketResult: rootmanager.PolicyDeletionResult{
 			AccountId: "123456789012", Success: false, Error: "access denied",
@@ -64,10 +58,9 @@ func TestDeleteS3BucketPolicyCommand_DeletionFailure(t *testing.T) {
 
 	cmd := Delete(newMockFactory(mock))
 	cmd.SilenceErrors = true
-	cmd.SetArgs([]string{"s3-bucket-policy", "--account", "123456789012", "--bucket", "my-bucket"})
+	cmd.SetArgs([]string{"s3-bucket-policy", "--account", "123456789012", "--bucket", "my-bucket", "--yes"})
 
-	// Non-interactive: confirm TUI will fail/return no-selection → "Aborted."
-	_ = cmd.Execute()
+	require.Error(t, cmd.Execute())
 }
 
 func TestDeleteS3BucketPolicyCommand_NoBucketsFoundInTUI(t *testing.T) {

--- a/cmd/delete_sqs_queue_policy.go
+++ b/cmd/delete_sqs_queue_policy.go
@@ -70,16 +70,16 @@ func runDeleteSQSQueuePolicy(newRM func(context.Context) (rootmanager.RootManage
 	if outputFlag == "table" {
 		fmt.Fprintf(w, "Current queue policy for %s:\n\n", queueUrl)
 		output.RenderPolicy(w, policy)
+	}
 
-		if !skipFlag {
-			confirmed, err := ui.Confirm("Delete this policy?")
-			if err != nil {
-				return err
-			}
-			if !confirmed {
-				fmt.Fprintln(w, "Aborted.")
-				return nil
-			}
+	if !skipFlag {
+		confirmed, err := ui.Confirm("Delete this policy?")
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			fmt.Fprintln(w, "Aborted.")
+			return nil
 		}
 	}
 

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -23,7 +23,7 @@ func TestDeleteCommand_Success(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := Delete(newMockFactory(mock))
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"all", "--accounts", "123456789012", "--skip"})
+	cmd.SetArgs([]string{"all", "--accounts", "123456789012", "--yes"})
 
 	require.NoError(t, cmd.Execute())
 	assert.NotEmpty(t, buf.String())
@@ -42,7 +42,7 @@ func TestDeleteCommand_CertificatesSubcommand(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := Delete(newMockFactory(mock))
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"certificates", "--accounts", "123456789012", "--skip"})
+	cmd.SetArgs([]string{"certificates", "--accounts", "123456789012", "--yes"})
 
 	require.NoError(t, cmd.Execute())
 	assert.NotEmpty(t, buf.String())
@@ -72,7 +72,7 @@ func TestDeleteCommand_DeleteFailure(t *testing.T) {
 
 	cmd := Delete(newMockFactory(mock))
 	cmd.SilenceErrors = true
-	cmd.SetArgs([]string{"all", "--accounts", "123456789012", "--skip"})
+	cmd.SetArgs([]string{"all", "--accounts", "123456789012", "--yes"})
 
 	require.Error(t, cmd.Execute())
 }

--- a/cmd/recovery.go
+++ b/cmd/recovery.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Recovery(newRM func(context.Context) (rootmanager.RootManager, error)) *cobra.Command {
-	var skip bool
 	cmd := &cobra.Command{
 		Use:   "recovery",
 		Short: "Allow root password recovery",
@@ -45,7 +44,7 @@ func Recovery(newRM func(context.Context) (rootmanager.RootManager, error)) *cob
 			}
 			slog.Debug("selected accounts", "accounts", strings.Join(targetAccounts, ", "))
 
-			if outputFlag == "table" && !skip {
+			if !skipFlag {
 				confirmed, err := ui.Confirm(fmt.Sprintf("Restore root password for %d account(s)?", len(targetAccounts)))
 				if err != nil {
 					return err
@@ -90,6 +89,6 @@ func Recovery(newRM func(context.Context) (rootmanager.RootManager, error)) *cob
 		},
 	}
 	cmd.PersistentFlags().StringSliceVarP(&accountsFlags, "accounts", "a", []string{}, "List of tarjet AWS account IDs (comma-separated). Use \"all\" to select all accounts.")
-	cmd.Flags().BoolVar(&skip, "skip", false, "Skip the confirmation prompt")
+	cmd.Flags().BoolVar(&skipFlag, "yes", false, "Skip the confirmation prompt")
 	return cmd
 }

--- a/cmd/recovery_test.go
+++ b/cmd/recovery_test.go
@@ -20,7 +20,7 @@ func TestRecoveryCommand_Success(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := Recovery(newMockFactory(mock))
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--accounts", "123456789012", "--skip"})
+	cmd.SetArgs([]string{"--accounts", "123456789012", "--yes"})
 
 	require.NoError(t, cmd.Execute())
 	assert.NotEmpty(t, buf.String())
@@ -36,7 +36,7 @@ func TestRecoveryCommand_AlreadyExists(t *testing.T) {
 	var buf bytes.Buffer
 	cmd := Recovery(newMockFactory(mock))
 	cmd.SetOut(&buf)
-	cmd.SetArgs([]string{"--accounts", "123456789012", "--skip"})
+	cmd.SetArgs([]string{"--accounts", "123456789012", "--yes"})
 
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, buf.String(), "already exists")
@@ -48,7 +48,7 @@ func TestRecoveryCommand_FactoryError(t *testing.T) {
 	cmd := Recovery(newFailingFactory(factoryErr))
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
-	cmd.SetArgs([]string{"--accounts", "123456789012"})
+	cmd.SetArgs([]string{"--accounts", "123456789012", "--yes"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -65,7 +65,7 @@ func TestRecoveryCommand_RecoveryFailure(t *testing.T) {
 	cmd := Recovery(newMockFactory(mock))
 	cmd.SilenceErrors = true
 	cmd.SilenceUsage = true
-	cmd.SetArgs([]string{"--accounts", "123456789012", "--skip"})
+	cmd.SetArgs([]string{"--accounts", "123456789012", "--yes"})
 
 	require.Error(t, cmd.Execute())
 }

--- a/internal/cli/ui/confirm.go
+++ b/internal/cli/ui/confirm.go
@@ -1,7 +1,18 @@
 package ui
 
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
+
 // Confirm shows a yes/no single-select TUI. Returns true if the user chose "Yes".
+// Returns an error if stdin is not a TTY — callers must pass --yes to skip confirmation in non-interactive environments.
 func Confirm(question string) (bool, error) {
+	if !term.IsTerminal(os.Stdin.Fd()) {
+		return false, fmt.Errorf("confirmation required: run in an interactive terminal or use --yes to confirm")
+	}
 	idx, err := PromptSingle(question, []string{"Yes", "No"})
 	if err != nil {
 		return false, err

--- a/internal/cli/ui/confirm_test.go
+++ b/internal/cli/ui/confirm_test.go
@@ -1,0 +1,19 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests run without a TTY (stdin is a pipe), so Confirm always hits the non-TTY branch.
+
+func TestConfirm_NonTTY_ReturnsError(t *testing.T) {
+	confirmed, err := Confirm("Delete credentials?")
+
+	require.Error(t, err)
+	assert.False(t, confirmed)
+	assert.True(t, strings.Contains(err.Error(), "--yes"), "error should mention --yes flag")
+}


### PR DESCRIPTION
- Replace `--skip` with `--yes` across all write commands.
- `ui.Confirm` now returns an error when stdin is not a TTY instead of auto-approving, forcing callers to pass `--yes` in CI/scripts. 
- Confirmation is always shown regardless of output format.